### PR TITLE
Bugfix in tree reader plugin

### DIFF
--- a/IO/line_reader_plugin.py
+++ b/IO/line_reader_plugin.py
@@ -47,55 +47,56 @@ class loaderClass(lasagna_plugin):
 
 
  #Slots follow
-    def showLoadDialog(self,fname=None):
+    def showLoadDialog(self,fnames=None):
         """
         This slot brings up the load dialog and retrieves the file name.
         If a filename is provided then this is loaded and no dialog is brought up.
         If the file name is valid, it loads the base stack using the load method.
         """
-        if fname == None or fname == False:
-            fname = self.lasagna.showFileLoadDialog(fileFilter="Text Files (*.txt *.csv)")
-    
-        if fname == None or fname == False:
-            return
+        if fnames == None or fnames == False:
+            fnames = self.lasagna.showFileLoadDialog(fileFilter="Text Files (*.txt *.csv)"
+                                                    , singleFile=False)
+        for fname in fnames:
+            if fname == None or fname == False:
+                return
 
-        if os.path.isfile(fname): 
-            with open(str(fname),'r') as fid:
-                contents = fid.read()
-    
+            if os.path.isfile(fname):
+                with open(str(fname),'r') as fid:
+                    contents = fid.read()
 
-            # a list of strings with each string being one line from the file
-            # add nans between lineseries
-            asList = contents.split('\n')
-            data=[]
-            lastLineSeries=None
-            n=0
-            for ii in range(len(asList)):
-                if len(asList[ii])==0:
-                    continue
 
-                thisLineAsFloats = [float(x) for x in asList[ii].split(',')]
-                if lastLineSeries==None:
+                # a list of strings with each string being one line from the file
+                # add nans between lineseries
+                asList = contents.split('\n')
+                data=[]
+                lastLineSeries=None
+                n=0
+                for ii in range(len(asList)):
+                    if len(asList[ii])==0:
+                        continue
+
+                    thisLineAsFloats = [float(x) for x in asList[ii].split(',')]
+                    if lastLineSeries==None:
+                        lastLineSeries=thisLineAsFloats[0]
+
+                    if lastLineSeries != thisLineAsFloats[0]:
+                        n+=1
+                        data.append([np.nan, np.nan, np.nan])
+
                     lastLineSeries=thisLineAsFloats[0]
-
-                if lastLineSeries != thisLineAsFloats[0]:
-                    n+=1
-                    data.append([np.nan, np.nan, np.nan])
-
-                lastLineSeries=thisLineAsFloats[0]
-                data.append(thisLineAsFloats[1:])
+                    data.append(thisLineAsFloats[1:])
 
 
-            objName=fname.split(os.path.sep)[-1]
-            self.lasagna.addIngredient(objectName=objName, 
-                        kind=self.kind,
-                        data=np.asarray(data), 
-                        fname=fname,
-                        )
+                objName=fname.split(os.path.sep)[-1]
+                self.lasagna.addIngredient(objectName=objName,
+                            kind=self.kind,
+                            data=np.asarray(data),
+                            fname=fname,
+                            )
 
-            self.lasagna.returnIngredientByName(objName).addToPlots() #Add item to all three 2D plots
-            self.lasagna.initialiseAxes()
+                self.lasagna.returnIngredientByName(objName).addToPlots() #Add item to all three 2D plots
+                self.lasagna.initialiseAxes()
 
 
-        else:
-            self.lasagna.statusBar.showMessage("Unable to find " + str(fname))
+            else:
+                self.lasagna.statusBar.showMessage("Unable to find " + str(fname))

--- a/imageStackLoader.py
+++ b/imageStackLoader.py
@@ -1,4 +1,3 @@
-
 """
 Read MHD stacks (using the vtk library) or TIFF stacks
 @author: Rob Campbell - Basel - git<a>raacampbell.com
@@ -8,472 +7,504 @@ https://github.com/raacampbell13/lasagna
 from __future__ import division
 import re
 import os
-import struct 
+import struct
 import numpy as np
-import imp #to look for the presence of a module. Python 3 will require importlib
-import lasagna_helperFunctions as lasHelp 
+import imp  # to look for the presence of a module. Python 3 will require importlib
+import lasagna_helperFunctions as lasHelp
 
 
-#-------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------
 #   *General methods*
 # The methods in this section are the ones that are called by by Lasagna or are called by other
 # functions in this module. They determine the correct loader methods, etc, for the file format 
 # so that Lasagna doesn't have to know about this. 
 
 def loadStack(fname):
-  """
-  loadStack determines the data type from the file extension determines what data are to be 
-  loaded and chooses the approproate function to return the data.
-  """
-  if fname.lower().endswith('.tif') or fname.lower().endswith('.tiff'):
-    return loadTiffStack(fname)
-  elif fname.lower().endswith('.mhd'):
-    return mhdRead(fname)
-  elif fname.lower().endswith('.nrrd') or fname.lower().endswith('.nrd'):
-    return nrrdRead(fname)
-  else:
-    print "\n\n*" + fname + " NOT LOADED. DATA TYPE NOT KNOWN\n\n"
+    """
+    loadStack determines the data type from the file extension determines what data are to be
+    loaded and chooses the approproate function to return the data.
+    """
+    if fname.lower().endswith('.tif') or fname.lower().endswith('.tiff'):
+        return loadTiffStack(fname)
+    elif fname.lower().endswith('.mhd'):
+        return mhdRead(fname)
+    elif fname.lower().endswith('.nrrd') or fname.lower().endswith('.nrd'):
+        return nrrdRead(fname)
+    else:
+        print
+        "\n\n*" + fname + " NOT LOADED. DATA TYPE NOT KNOWN\n\n"
 
+def saveStack(fname, data, format='tif'):
+    """Save the image data
+    Works only for tif for now
+    """
+
+    format = format.lower().strip().strip('.')
+    if format not in ['tif', 'tiff']:
+        raise NotImplementedError
+    saveTiffStack(fname, data)
 
 def imageFilter():
-  """
-  Returns a string defining the filter for the Qt Loader dialog. 
-  As image formats are added (or removed) from this module, this 
-  string should be manually modified accordingly.
-  """
-  return "Images (*.mhd *.tiff *.tif *.nrrd *.nrd)"
+    """
+    Returns a string defining the filter for the Qt Loader dialog.
+    As image formats are added (or removed) from this module, this
+    string should be manually modified accordingly.
+    """
+    return "Images (*.mhd *.tiff *.tif *.nrrd *.nrd)"
 
 
-def getVoxelSpacing(fname,fallBackMode=False):
-  """
-  Attempts to get the voxel spacing in all three dimensions. This allows us to set the axis
-  ratios automatically. TODO: Currently this will only work for MHD files, but we may be able 
-  to swing something for TIFFs (e.g. by creating Icy-like metadata files)
-  """
+def getVoxelSpacing(fname, fallBackMode=False):
+    """
+    Attempts to get the voxel spacing in all three dimensions. This allows us to set the axis
+    ratios automatically. TODO: Currently this will only work for MHD files, but we may be able
+    to swing something for TIFFs (e.g. by creating Icy-like metadata files)
+    """
 
-  if fname.lower().endswith('.mhd'):
-    return mhd_getRatios(fname)
-  if fname.lower().endswith('.nrrd') or fname.lower().endswith('.nrd'):  
-    return nrrd_getRatios(fname)
-  else:
-    return lasHelp.readPreference('defaultAxisRatios') #defaults
+    if fname.lower().endswith('.mhd'):
+        return mhd_getRatios(fname)
+    if fname.lower().endswith('.nrrd') or fname.lower().endswith('.nrd'):
+        return nrrd_getRatios(fname)
+    else:
+        return lasHelp.readPreference('defaultAxisRatios')  # defaults
 
 
 def spacingToRatio(spacing):
-  """
-  Takes a vector of axis spacings and converts it to ratios
-  so Lasagna can plot the images correctly
-  Expects spacing to have a length of 3
-  """
-  assert len(spacing) == 3
+    """
+    Takes a vector of axis spacings and converts it to ratios
+    so Lasagna can plot the images correctly
+    Expects spacing to have a length of 3
+    """
+    assert len(spacing) == 3
 
-  ratios = [0,0,0]
-  ratios[0] = spacing[0]/spacing[1]
-  ratios[1] = spacing[2]/spacing[0]
-  ratios[2] = spacing[1]/spacing[2]
-  return ratios
+    ratios = [0, 0, 0]
+    ratios[0] = spacing[0] / spacing[1]
+    ratios[1] = spacing[2] / spacing[0]
+    ratios[2] = spacing[1] / spacing[2]
+    return ratios
 
 
-#-------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------
 #   *TIFF handling methods*
-def loadTiffStack(fname,useLibTiff=False):
-  """
-  Read a TIFF stack.
-  We're using tifflib by default as, right now, only this works when the application is compile on Windows. [17/08/15]
-  Bugs: known to fail with tiffs produced by Icy [23/07/15]
+def loadTiffStack(fname, useLibTiff=False):
+    """
+    Read a TIFF stack.
+    We're using tifflib by default as, right now, only this works when the application is compile on Windows. [17/08/15]
+    Bugs: known to fail with tiffs produced by Icy [23/07/15]
 
-  """
-  if not os.path.exists(fname):
-    print "imageStackLoader.loadTiffStack can not find %s" % fname
-    return
+    """
+    if not os.path.exists(fname):
+        print
+        "imageStackLoader.loadTiffStack can not find %s" % fname
+        return
 
-  purePython = True
-  if useLibTiff:
-    from libtiff import TIFFfile
-    import numpy as np
-    tiff = TIFFfile(fname)
-    samples, sample_names = tiff.get_samples() #we should have just one
-    print "Loading:\n" + tiff.get_info() + " with libtiff\n"
-    im = np.asarray(samples[0])
-  else:
-    print "Loading:\n" + fname + " with tifffile\n"
-    from tifffile import imread 
-    im = imread(fname)
+    purePython = True
+    if useLibTiff:
+        from libtiff import TIFFfile
+        import numpy as np
+        tiff = TIFFfile(fname)
+        samples, sample_names = tiff.get_samples()  # we should have just one
+        print
+        "Loading:\n" + tiff.get_info() + " with libtiff\n"
+        im = np.asarray(samples[0])
+    else:
+        print
+        "Loading:\n" + fname + " with tifffile\n"
+        from tifffile import imread
+        im = imread(fname)
 
-  im=im.swapaxes(1,2) 
-  print "read image of size: cols: %d, rows: %d, layers: %d" % (im.shape[1],im.shape[2],im.shape[0])
-  return im
+    im = im.swapaxes(1, 2)
+    print
+    "read image of size: cols: %d, rows: %d, layers: %d" % (im.shape[1], im.shape[2], im.shape[0])
+    return im
 
 
+def saveTiffStack(fname, data, useLibTiff = False):
+    """Save data in file fname
+    """
 
-#-------------------------------------------------------------------------------------------
+    if useLibTiff:
+        raise NotImplementedError
+    from tifffile import imsave
+    imsave(fname, data.swapaxes(1,2))
+
+# -------------------------------------------------------------------------------------------
 #   *MHD handling methods*
-def mhdRead(fname,fallBackMode = False):
-  """
-  Read an MHD file using either VTK (if available) or the slower-built in reader
-  if fallBackMode is true we force use of the built-in reader
-  """
-  if fallBackMode == False: 
-    #Attempt to load vtk
-    try:
-      imp.find_module('vtk')
-      import vtk
-      from vtk.util.numpy_support import vtk_to_numpy
-    except ImportError:
-      print "Failed to find VTK. Falling back to built in (but slower) MHD reader"
-      fallBackMode = True
+def mhdRead(fname, fallBackMode=False):
+    """
+    Read an MHD file using either VTK (if available) or the slower-built in reader
+    if fallBackMode is true we force use of the built-in reader
+    """
+    if fallBackMode == False:
+        # Attempt to load vtk
+        try:
+            imp.find_module('vtk')
+            import vtk
+            from vtk.util.numpy_support import vtk_to_numpy
+        except ImportError:
+            print
+            "Failed to find VTK. Falling back to built in (but slower) MHD reader"
+            fallBackMode = True
 
-  if fallBackMode:
-    return mhdRead_fallback(fname)
-  else:
-    #use VTK
-    imr = vtk.vtkMetaImageReader()
-    imr.SetFileName(fname)
-    imr.Update()
+    if fallBackMode:
+        return mhdRead_fallback(fname)
+    else:
+        # use VTK
+        imr = vtk.vtkMetaImageReader()
+        imr.SetFileName(fname)
+        imr.Update()
 
-    im = imr.GetOutput()
+        im = imr.GetOutput()
 
-    rows, cols, z = im.GetDimensions()
-    sc = im.GetPointData().GetScalars()
-    a = vtk_to_numpy(sc)
-    a = a.reshape(z, cols, rows) 
-    a = a.swapaxes(1,2)
-    print "Using VTK to read MHD image of size: cols: %d, rows: %d, layers: %d" % (rows,cols,z)
-    return a    
+        rows, cols, z = im.GetDimensions()
+        sc = im.GetPointData().GetScalars()
+        a = vtk_to_numpy(sc)
+        a = a.reshape(z, cols, rows)
+        a = a.swapaxes(1, 2)
+        print
+        "Using VTK to read MHD image of size: cols: %d, rows: %d, layers: %d" % (rows, cols, z)
+        return a
 
 
-def mhdWrite(imStack,fname):
-  """
-  Write MHD file, updating both the MHD and raw file.
-  imStack - is the image stack volume ndarray
-  fname - is the absolute path to the mhd file.
-  """
-  imStack = np.swapaxes(imStack,1,2)
-  out = mhd_write_raw_file(imStack,fname)
-  if out==False:
-    return False
-  else:
-    info=out
+def mhdWrite(imStack, fname):
+    """
+    Write MHD file, updating both the MHD and raw file.
+    imStack - is the image stack volume ndarray
+    fname - is the absolute path to the mhd file.
+    """
+    imStack = np.swapaxes(imStack, 1, 2)
+    out = mhd_write_raw_file(imStack, fname)
+    if out == False:
+        return False
+    else:
+        info = out
 
-  #Write the mhd header file, as it may have been modified
-  print "Saving image of size %s" % str(imStack.shape)
-  mhd_write_header_file(fname,info)
-  return True
+    # Write the mhd header file, as it may have been modified
+    print
+    "Saving image of size %s" % str(imStack.shape)
+    mhd_write_header_file(fname, info)
+    return True
 
 
 def mhdRead_fallback(fname):
-  """
-  Read the header file from the MHA file then use this to 
-  build a 3D stack from the raw file
+    """
+    Read the header file from the MHA file then use this to
+    build a 3D stack from the raw file
 
-  fname should be the name of the mhd (header) file
-  """
+    fname should be the name of the mhd (header) file
+    """
 
-  if os.path.exists(fname) == False:
-    print "mha_read can not find file %s" % fname
-    return False
-  else:
-    info = mhd_read_header_file(fname)
-    if len(info)==0:
-      print "No data extracted from header file"
-      return False
-
-
-  if info.has_key('dimsize') == False:
-    print "Can not find dimension size information in MHD file. Not importing data"
-    return False
-
-
-  #read the raw file
-  if info.has_key('elementdatafile') == False:
-    print "Can not find the data file as the key 'elementdatafile' does not exist in the MHD file"
-    return False
-
-  return mhd_read_raw_file(fname,info)
-
-
-
-def mhd_read_raw_file(fname,header):
-  """
-  Raw .raw file associated with the MHD header file
-  CAUTION: this may not adhere to MHD specs! Report bugs to author.
-  """
-
-  if header.has_key('headersize'):
-    if header['headersize']>0:
-      print "\n\n **MHD reader can not currently cope with header information in .raw file. Contact the author** \n\n"
-      return False
-
-  #Set the endian type correctly
-  if header.has_key('byteorder'):
-    if header['byteorder'].lower == 'true' :
-      endian = '>' #big endian
+    if os.path.exists(fname) == False:
+        print
+        "mha_read can not find file %s" % fname
+        return False
     else:
-      endian = '<' #little endian
-  else:
-    endian = '<' #little endian
+        info = mhd_read_header_file(fname)
+        if len(info) == 0:
+            print
+            "No data extracted from header file"
+            return False
+
+    if info.has_key('dimsize') == False:
+        print
+        "Can not find dimension size information in MHD file. Not importing data"
+        return False
+
+    # read the raw file
+    if info.has_key('elementdatafile') == False:
+        print
+        "Can not find the data file as the key 'elementdatafile' does not exist in the MHD file"
+        return False
+
+    return mhd_read_raw_file(fname, info)
 
 
-  #Set the data type correctly 
-  if header.has_key('datatype'):
-    datatype = header['datatype'].lower()
+def mhd_read_raw_file(fname, header):
+    """
+    Raw .raw file associated with the MHD header file
+    CAUTION: this may not adhere to MHD specs! Report bugs to author.
+    """
 
-    if datatype == 'float':
-      formatType = 'f'
-    elif datatype == 'double':
-      formatType = 'd'
-    elif datatype == 'long':
-      formatType = 'l'
-    elif datatype == 'ulong':
-      formatType = 'L'
-    elif datatype == 'char':
-      formatType = 'c'
-    elif datatype == 'uchar':
-      formatType = 'B'
-    elif datatype == 'short':
-      formatType = 'h'      
-    elif datatype == 'ushort':
-      formatType = 'H'      
-    elif datatype == 'int':
-      formatType = 'i'      
-    elif datatype == 'uint':
-      formatType = 'I'
+    if header.has_key('headersize'):
+        if header['headersize'] > 0:
+            print
+            "\n\n **MHD reader can not currently cope with header information in .raw file. Contact the author** \n\n"
+            return False
+
+    # Set the endian type correctly
+    if header.has_key('byteorder'):
+        if header['byteorder'].lower == 'true':
+            endian = '>'  # big endian
+        else:
+            endian = '<'  # little endian
     else:
-      formatType = False
+        endian = '<'  # little endian
 
-  else:
-      formatType = False
+    # Set the data type correctly
+    if header.has_key('datatype'):
+        datatype = header['datatype'].lower()
 
-  if formatType == False:
-    print "\nCan not find data format type in MHD file. **CONTACT AUTHOR**\n"
-    return False
+        if datatype == 'float':
+            formatType = 'f'
+        elif datatype == 'double':
+            formatType = 'd'
+        elif datatype == 'long':
+            formatType = 'l'
+        elif datatype == 'ulong':
+            formatType = 'L'
+        elif datatype == 'char':
+            formatType = 'c'
+        elif datatype == 'uchar':
+            formatType = 'B'
+        elif datatype == 'short':
+            formatType = 'h'
+        elif datatype == 'ushort':
+            formatType = 'H'
+        elif datatype == 'int':
+            formatType = 'i'
+        elif datatype == 'uint':
+            formatType = 'I'
+        else:
+            formatType = False
+
+    else:
+        formatType = False
+
+    if formatType == False:
+        print
+        "\nCan not find data format type in MHD file. **CONTACT AUTHOR**\n"
+        return False
+
+    pathToFile = lasHelp.stripTrailingFileFromPath(fname)
+    rawFname = os.path.join(pathToFile, header['elementdatafile'])
+    with  open(rawFname, 'rb') as fid:
+        data = fid.read()
+
+    dimSize = header['dimsize']
+    # from: http://stackoverflow.com/questions/26542345/reading-data-from-a-16-bit-unsigned-big-endian-raw-image-file-in-python
+    fmt = endian + str(int(np.prod(dimSize))) + formatType
+    pix = np.asarray(struct.unpack(fmt, data))
+
+    return pix.reshape((dimSize[2], dimSize[1], dimSize[0])).swapaxes(1, 2)
 
 
-  pathToFile = lasHelp.stripTrailingFileFromPath(fname)
-  rawFname = os.path.join(pathToFile,header['elementdatafile'])
-  with  open(rawFname,'rb') as fid:
-    data = fid.read()
-    
-  dimSize = header['dimsize']
-  #from: http://stackoverflow.com/questions/26542345/reading-data-from-a-16-bit-unsigned-big-endian-raw-image-file-in-python
-  fmt = endian + str(int(np.prod(dimSize))) + formatType
-  pix = np.asarray(struct.unpack(fmt, data))
-  
-  return pix.reshape((dimSize[2],dimSize[1],dimSize[0])).swapaxes(1,2)
+def mhd_write_raw_file(imStack, fname, info=None):
+    """
+    Write raw MHD file.
+    imStack - is the image stack volume ndarray
+    fname - is the absolute path to the mhd file.
+    info - is a dictionary containing imported data from the mhd file. This is optional.
+          If info is missing, we read the data from the mhd file
+    """
 
+    if info == None:
+        info = mhd_read_header_file(fname)
 
-def mhd_write_raw_file(imStack,fname,info=None):
-  """
-  Write raw MHD file.
-  imStack - is the image stack volume ndarray
-  fname - is the absolute path to the mhd file.
-  info - is a dictionary containing imported data from the mhd file. This is optional. 
-        If info is missing, we read the data from the mhd file
-  """
+    # Get the name of the raw file and check it exists
+    path = os.path.dirname(fname)
+    pathToRaw = path + os.path.sep + info['elementdatafile']
 
-  if info==None:
-    info=mhd_read_header_file(fname)
+    if not os.path.exists(pathToRaw):
+        print
+        "Unable to find raw file at %s. Aborting mhd_write_raw_file" % pathToRaw
+        return False
 
-  #Get the name of the raw file and check it exists
-  path = os.path.dirname(fname)
-  pathToRaw = path + os.path.sep + info['elementdatafile']
+    # replace the stack dimension sizes in the info stack in case the user changed this
+    info['dimsize'] = imStack.shape[::-1]  # We need to flip the list for some reason
 
-  if not os.path.exists(pathToRaw):
-    print "Unable to find raw file at %s. Aborting mhd_write_raw_file" % pathToRaw
-    return False
-
-
-  #replace the stack dimension sizes in the info stack in case the user changed this
-  info['dimsize'] = imStack.shape[::-1] #We need to flip the list for some reason
-
-  #TODO: the endianness is not set here or defined in the MHD file. Does this matter?
-  try:
-    with open(pathToRaw,'wb') as fid:
-      fid.write( bytearray(imStack.ravel()) )
-    return info
-  except IOError:
-    print "Failed to write raw file in mhd_write_raw_file"
-    return False
+    # TODO: the endianness is not set here or defined in the MHD file. Does this matter?
+    try:
+        with open(pathToRaw, 'wb') as fid:
+            fid.write(bytearray(imStack.ravel()))
+        return info
+    except IOError:
+        print
+        "Failed to write raw file in mhd_write_raw_file"
+        return False
 
 
 def mhd_read_header_file(fname):
-  """
-  Read an MHD plain text header file and return contents as a dictionary
-  """
+    """
+    Read an MHD plain text header file and return contents as a dictionary
+    """
 
-  mhd_header = dict()
-  mhd_header['FileName'] = fname
+    mhd_header = dict()
+    mhd_header['FileName'] = fname
 
-  with open(fname,'r') as fid:
-    contents = fid.read()
+    with open(fname, 'r') as fid:
+        contents = fid.read()
 
+    info = dict()  # header data stored here
 
-  info = dict() #header data stored here
+    for line in contents.split('\n'):
+        if len(line) == 0:
+            continue
 
-  for line in contents.split('\n'):
-    if len(line)==0:
-      continue
+        m = re.match('\A(\w+)', line)
+        if m == None:
+            continue
 
-    m=re.match('\A(\w+)',line)
-    if m == None:
-      continue
+        key = m.groups()[0].lower()  # This is the data key
 
-    key = m.groups()[0].lower() #This is the data key
+        # Now we get the data
+        m = re.match('\A\w+ *= * (.*) *', line)
+        if m == None:
+            print
+            "Can not get data for key %s" % key
+            continue
 
-    #Now we get the data
-    m=re.match('\A\w+ *= * (.*) *',line)
-    if m == None:
-      print "Can not get data for key %s" % key
-      continue
+        if len(m.groups()) > 1:
+            print
+            "multiple matches found during mhd_read_header_file. skipping " + key
+            continue
 
-    if len(m.groups())>1:
-      print "multiple matches found during mhd_read_header_file. skipping " + key
-      continue
+        # If we're here, we found reasonable data
+        data = m.groups()[0]
 
-    #If we're here, we found reasonable data
-    data = m.groups()[0] 
+        # If there are any characters not associated with a number we treat as a string and add to the dict
+        if re.match('.*[^0-9 \.].*', data) != None:
+            info[key] = data
+            continue
 
-    #If there are any characters not associated with a number we treat as a string and add to the dict
-    if re.match('.*[^0-9 \.].*',data) != None:
-      info[key] = data
-      continue
+        # Otherwise we have a single number of a list of numbers in space-separated form.
+        # So we return these as a list or a single number. We convert everything to float just in
+        # case it's not an integer.
+        data = data.split(' ')
+        numbers = []
+        for number in data:
+            if len(number) > 0:
+                numbers.append(float(number))
 
-    #Otherwise we have a single number of a list of numbers in space-separated form. 
-    #So we return these as a list or a single number. We convert everything to float just in
-    #case it's not an integer. 
-    data = data.split(' ')
-    numbers = []
-    for number in data:
-      if len(number)>0:
-        numbers.append(float(number))
+        # If the list has just one number we return an int
+        if len(numbers) == 1:
+            numbers = float(numbers[0])
 
-    #If the list has just one number we return an int
-    if len(numbers)==1:
-      numbers = float(numbers[0])
+        info[key] = numbers
 
-    info[key] = numbers
-
-  return info
-
-
-def mhd_write_header_file(fname,info):
-  """
-  This is a quick and very dirty, *SIMPLE*, mhd header writer. It can only cope with the fields hard-coded described below. 
-  """
-
-  fileStr = '' #Build a string that we will write to a file
-  if info.has_key('ndims'):
-    fileStr = fileStr + ('NDims = %d\n' % info['ndims'])
-
-  if info.has_key('datatype'):
-    fileStr = fileStr + ('DataType = %s\n' % info['datatype'])
-
-  if info.has_key('dimsize'):
-    numbers = ' '.join(map(str,(map(int,info['dimsize'])))) #convert a list of floats into a space separated series of ints
-    fileStr = fileStr + ('DimSize = %s\n' % numbers)
-
-  if info.has_key('elementsize'):
-    numbers = ' '.join(map(str,(map(int,info['elementsize'])))) 
-    fileStr = fileStr + ('ElementSize = %s\n' % numbers)
-
-  if info.has_key('elementspacing'):
-    numbers = ' '.join(map(str,(map(int,info['elementspacing'])))) 
-    fileStr = fileStr + ('ElementSpacing = %s\n' % numbers)
-
-  if info.has_key('elementtype'):
-    fileStr = fileStr + ('ElementType = %s\n' % info['elementtype'])
-  
-  if info.has_key('elementbyteordermsb'):
-    fileStr = fileStr + ('ElementByteOrderMSB = %s\n' % str(info['elementbyteordermsb']))
-
-  if info.has_key('elementdatafile'):
-    fileStr = fileStr + ('ElementDataFile = %s\n' % info['elementdatafile'])
+    return info
 
 
-  #If we're here, then hopefully things went well. We write to the file
-  with open (fname,'w') as fid:
-    fid.write(fileStr)
+def mhd_write_header_file(fname, info):
+    """
+    This is a quick and very dirty, *SIMPLE*, mhd header writer. It can only cope with the fields hard-coded described below.
+    """
+
+    fileStr = ''  # Build a string that we will write to a file
+    if info.has_key('ndims'):
+        fileStr = fileStr + ('NDims = %d\n' % info['ndims'])
+
+    if info.has_key('datatype'):
+        fileStr = fileStr + ('DataType = %s\n' % info['datatype'])
+
+    if info.has_key('dimsize'):
+        numbers = ' '.join(
+            map(str, (map(int, info['dimsize']))))  # convert a list of floats into a space separated series of ints
+        fileStr = fileStr + ('DimSize = %s\n' % numbers)
+
+    if info.has_key('elementsize'):
+        numbers = ' '.join(map(str, (map(int, info['elementsize']))))
+        fileStr = fileStr + ('ElementSize = %s\n' % numbers)
+
+    if info.has_key('elementspacing'):
+        numbers = ' '.join(map(str, (map(int, info['elementspacing']))))
+        fileStr = fileStr + ('ElementSpacing = %s\n' % numbers)
+
+    if info.has_key('elementtype'):
+        fileStr = fileStr + ('ElementType = %s\n' % info['elementtype'])
+
+    if info.has_key('elementbyteordermsb'):
+        fileStr = fileStr + ('ElementByteOrderMSB = %s\n' % str(info['elementbyteordermsb']))
+
+    if info.has_key('elementdatafile'):
+        fileStr = fileStr + ('ElementDataFile = %s\n' % info['elementdatafile'])
+
+    # If we're here, then hopefully things went well. We write to the file
+    with open(fname, 'w') as fid:
+        fid.write(fileStr)
 
 
 def mhd_getRatios(fname):
-  """
-  Get relative axis ratios from MHD file defined by fname
-  """
-  if not os.path.exists(fname):
-    print "imageStackLoader.mhd_getRatios can not find %s" % fname
-    return
-    
-  try:
-    #Attempt to use the vtk module to read the element spacing
-    imp.find_module('vtk')
-    import vtk
-    imr = vtk.vtkMetaImageReader()
-    imr.SetFileName(fname)
-    imr.Update()
- 
-    im = imr.GetOutput()
-    spacing = im.GetSpacing()    
-  except ImportError:
-    #If the vtk module fails, we try to read the spacing using the built-in reader
-    info = mhd_read_header_file(fname)
-    if info.has_key('elementspacing'):
-      spacing = info['elementspacing']
-    else:
-      print "Failed to find spacing info in MHA file. Using default axis length values"      
-      return lasHelp.readPreference('defaultAxisRatios') #defaults
+    """
+    Get relative axis ratios from MHD file defined by fname
+    """
+    if not os.path.exists(fname):
+        print
+        "imageStackLoader.mhd_getRatios can not find %s" % fname
+        return
+
+    try:
+        # Attempt to use the vtk module to read the element spacing
+        imp.find_module('vtk')
+        import vtk
+        imr = vtk.vtkMetaImageReader()
+        imr.SetFileName(fname)
+        imr.Update()
+
+        im = imr.GetOutput()
+        spacing = im.GetSpacing()
+    except ImportError:
+        # If the vtk module fails, we try to read the spacing using the built-in reader
+        info = mhd_read_header_file(fname)
+        if info.has_key('elementspacing'):
+            spacing = info['elementspacing']
+        else:
+            print
+            "Failed to find spacing info in MHA file. Using default axis length values"
+            return lasHelp.readPreference('defaultAxisRatios')  # defaults
+
+    if len(spacing) == 0:
+        print
+        "Failed to find spacing valid spacing info in MHA file. Using default axis length values"
+        return lasHelp.readPreference('defaultAxisRatios')  # defaults
+
+    return spacingToRatio(spacing)
 
 
-  if len(spacing)==0: 
-    print "Failed to find spacing valid spacing info in MHA file. Using default axis length values"      
-    return lasHelp.readPreference('defaultAxisRatios') #defaults
-  
-  return spacingToRatio(spacing)  
-
-
-
-#-------------------------------------------------------------------------------------------
+# -------------------------------------------------------------------------------------------
 #   *NRRD handling methods*
 def nrrdRead(fname):
-  """
-  Read NRRD file
-  """
-  if not os.path.exists(fname):
-    print "imageStackLoader.nrrdRead can not find %s" % fname
-    return
+    """
+    Read NRRD file
+    """
+    if not os.path.exists(fname):
+        print
+        "imageStackLoader.nrrdRead can not find %s" % fname
+        return
 
-  import nrrd 
-  (data,header) = nrrd.read(fname)
-  return data.swapaxes(1,2)
+    import nrrd
+    (data, header) = nrrd.read(fname)
+    return data.swapaxes(1, 2)
 
 
 def nrrdHeaderRead(fname):
-  """
-  Read NRRD header
-  """
-  if not os.path.exists(fname):
-    print "imageStackLoader.nrrdHeaderRead can not find %s" % fname
-    return
+    """
+    Read NRRD header
+    """
+    if not os.path.exists(fname):
+        print
+        "imageStackLoader.nrrdHeaderRead can not find %s" % fname
+        return
 
-  import nrrd
-  with open(fname,'rb') as fid:
-    header = nrrd.read_header(fid)
+    import nrrd
+    with open(fname, 'rb') as fid:
+        header = nrrd.read_header(fid)
 
-  return header
+    return header
 
 
 def nrrd_getRatios(fname):
-  """
-  Get the aspect ratios from the NRRD file
-  """
-  if not os.path.exists(fname):
-    print "imageStackLoader.nrrd_getRatios can not find %s" % fname
-    return
+    """
+    Get the aspect ratios from the NRRD file
+    """
+    if not os.path.exists(fname):
+        print
+        "imageStackLoader.nrrd_getRatios can not find %s" % fname
+        return
 
-  header = nrrdHeaderRead(fname)
-  axSizes = header['space directions']
+    header = nrrdHeaderRead(fname)
+    axSizes = header['space directions']
 
-  spacing =[]
-  for ii in range(len(axSizes)):
-    spacing.append(axSizes[ii][ii])
+    spacing = []
+    for ii in range(len(axSizes)):
+        spacing.append(axSizes[ii][ii])
 
-  return spacingToRatio(spacing)
+    return spacingToRatio(spacing)

--- a/ingredients/lines.py
+++ b/ingredients/lines.py
@@ -156,5 +156,16 @@ class lines(lasagna_ingredient):
         self._alpha = alpha        
     alpha = property(get_alpha,set_alpha)
 
-
+    def save(self, path=None):
+        if path is None:
+            path = QtGui.QFileDialog.getSaveFileName(self.parent, 'File to save %s'%self.objectName)
+        if not path:
+            return
+        line_series= 0
+        with open(path, 'w') as F:
+            for c in self.raw_data():
+                if all(np.isnan(c)): # if there is a line with 3 nans, it's another line series
+                    line_series+=1
+                F.write(','.join(['%i'%line_series]+['%s'%i for i in c])+'\n')
+        print '%s saved as %s'%(self.objectName, path)
    

--- a/ingredients/lines.py
+++ b/ingredients/lines.py
@@ -158,7 +158,8 @@ class lines(lasagna_ingredient):
 
     def save(self, path=None):
         if path is None:
-            path = QtGui.QFileDialog.getSaveFileName(self.parent, 'File to save %s'%self.objectName)
+            path = QtGui.QFileDialog.getSaveFileName(self.parent, 'File to save %s'%self.objectName,
+                                                     self.objectName)
         if not path:
             return
         line_series= 0

--- a/ingredients/sparsepoints.py
+++ b/ingredients/sparsepoints.py
@@ -139,7 +139,8 @@ class sparsepoints(lasagna_ingredient):
 
     def save(self, path=None):
         if path is None:
-            path = QtGui.QFileDialog.getSaveFileName(self.parent, 'File to save %s'%self.objectName)
+            path = QtGui.QFileDialog.getSaveFileName(self.parent, 'File to save %s'%self.objectName,
+                                                     self.objectName)
         if not path:
             return
         with open(path, 'w') as F:

--- a/ingredients/sparsepoints.py
+++ b/ingredients/sparsepoints.py
@@ -137,6 +137,16 @@ class sparsepoints(lasagna_ingredient):
             print "sparsepoints.color can not cope with type " + type(self.color)
 
 
+    def save(self, path=None):
+        if path is None:
+            path = QtGui.QFileDialog.getSaveFileName(self.parent, 'File to save %s'%self.objectName)
+        if not path:
+            return
+        with open(path, 'w') as F:
+            for c in self.raw_data():
+                F.write(','.join(['%s'%i for i in c])+'\n')
+        print '%s saved as %s'%(self.objectName, path)
+
     #---------------------------------------------------------------
     #Getters and setters
 

--- a/lasagna.py
+++ b/lasagna.py
@@ -475,23 +475,30 @@ class lasagna(QtGui.QMainWindow, lasagna_mainWindow.Ui_lasagna_mainWindow):
 
     # -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  -  
     #Code to handle generic file loading, dialogs, etc
-    def showFileLoadDialog(self, fileFilter="All files (*)" ):
+    def showFileLoadDialog(self, fileFilter="All files (*)", singleFile=True):
         """
         Bring up the file load dialog. Return the file name. Update the last used path. 
         """
         self.runHook(self.hooks['showFileLoadDialog_Start'])
-        fname = QtGui.QFileDialog.getOpenFileName(self, 'Open file', lasHelp.readPreference('lastLoadDir'), fileFilter)
-        fname = str(fname)
-        if len(fname) == 0:
-            return None
+        if singleFile:
+            sgl_fname = QtGui.QFileDialog.getOpenFileName(self, 'Open file', lasHelp.readPreference('lastLoadDir'),
+                                                      fileFilter)
+            sgl_fname = str(sgl_fname)
+            if len(sgl_fname) == 0:
+                return None
+            fname=sgl_fname
+        else:
+            fname = QtGui.QFileDialog.getOpenFileNames(self, 'Open file', lasHelp.readPreference('lastLoadDir'),
+                                                        fileFilter)
+            sgl_fname = str(fname[0]) # take one of the file to get path and add to history
 
         #Update last loaded directory 
-        lasHelp.preferenceWriter('lastLoadDir', lasHelp.stripTrailingFileFromPath(fname))
+        lasHelp.preferenceWriter('lastLoadDir', lasHelp.stripTrailingFileFromPath(sgl_fname))
 
         #Keep a track of the last loaded files
         recentlyLoaded = lasHelp.readPreference('recentlyLoadedFiles')
         n = lasHelp.readPreference('numRecentFiles')
-        recentlyLoaded.append(fname)
+        recentlyLoaded.append(sgl_fname)
         recentlyLoaded = list(set(recentlyLoaded)) #get remove repeats (i.e. keep only unique values)
 
         while len(recentlyLoaded)>n:

--- a/lasagna.py
+++ b/lasagna.py
@@ -833,8 +833,20 @@ class lasagna(QtGui.QMainWindow, lasagna_mainWindow.Ui_lasagna_mainWindow):
         action = QtGui.QAction("Delete",self)
         action.triggered.connect(self.deleteLayerPoints_Slot)
         menu.addAction(action)
+        action = QtGui.QAction("Save",self)
+        action.triggered.connect(self.saveLayerPoints_Slot)
+        menu.addAction(action)
+
         menu.exec_(self.points_TreeView.viewport().mapToGlobal(position))
 
+    def saveLayerPoints_Slot(self):
+        """call ingredient save method if any"""
+        objName =  self.selectedPointsName()
+        ingr = self.returnIngredientByName(objName)
+        if hasattr(ingr, 'save'):
+            ingr.save()
+        else:
+            print 'no save method for %s'%objName
 
     def deleteLayerPoints_Slot(self):
         objName =  self.selectedPointsName()

--- a/lasagna_helperFunctions.py
+++ b/lasagna_helperFunctions.py
@@ -18,17 +18,17 @@ def findPyQtGraphObjectNameInPlotWidget(PlotWidget,itemName,regex=False):
 
     Inputs:
     PlotWidget - an instance of a PyQtGraph plot widget
-    itemName - a string defining the .objectName to search for in PlotWidget. 
+    itemName - a string defining the .objectName to search for in PlotWidget.
     regex - if True the itemName is treated as a regular expression. [False by default]
 
     Outputs:
     Returns the instance of the object bearing the chosen name. Returns None if no
-    object was found. 
+    object was found.
 
     Notes:
     The user must assign a sensible name to every created plot item. Added objects will
     by default have a blank object name. This function does not do a recursive search,
-    so you can't feed it the GUI root object and expect an answer. It returns *ONLY* the 
+    so you can't feed it the GUI root object and expect an answer. It returns *ONLY* the
     first found item.
     """
 
@@ -105,7 +105,7 @@ def absPathToLasagna():
 
 def getLasagna_prefDir():
     """
-    Returns the path to lasagna preferences directory. 
+    Returns the path to lasagna preferences directory.
     If it does not exist it creates it and then returns the path
     """
     prefDir = getHomeDir() +'.lasagna'
@@ -125,8 +125,8 @@ def getLasagna_prefDir():
 def getLasagnaPrefFile():
     """
     Returns the location of the main lasagna preferences file.
-    It does not matter if the file does not exist, since it will be 
-    created on demand by other functions. 
+    It does not matter if the file does not exist, since it will be
+    created on demand by other functions.
     """
     return getLasagna_prefDir() + 'lasagna_prefs.yml'
 
@@ -136,8 +136,8 @@ def getLasagnaPrefFile():
 
 
 
- #     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
- #   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  
+ #     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ #   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
  # Functions that handle preferences
 def defaultPreferences():
@@ -146,17 +146,17 @@ def defaultPreferences():
     Return a dictionary containing the default lasagna preferences. This is necessary
     in case a particular preference is missing or the preferences file is missing.
     """
-    
+
     return {
             'lastLoadDir' : getHomeDir(),           #The directory from which we last loaded data
             'numRecentFiles' : 5,                   #The number of recently loaded file names to store
             'recentlyLoadedFiles' : [],             #A list containing the last "numRecentFiles" file names
             'IO_modulePaths' : [absPathToLasagna()+'IO'], #must be asbolute paths
-            'pluginPaths' : [absPathToLasagna()+'tutorialPlugins', 
-                             absPathToLasagna()+'registrationPlugins', 
+            'pluginPaths' : [absPathToLasagna()+'tutorialPlugins',
+                             absPathToLasagna()+'registrationPlugins',
                              absPathToLasagna()+'ARA'], #must be asbolute paths
             'defaultAxisRatios' : [1,2,0.5],        #The default axis ratios
-            'showCrossHairs' : True,                 #Whether or not to show the cross hairs 
+            'showCrossHairs' : True,                 #Whether or not to show the cross hairs
             'colorOrder' : ['red','green','blue','magenta','cyan','yellow','gray'], #The order in which colors appear by default (see imagestack class)
             'symbolOrder' : ['o','s','t','d','+'],
             'defaultLineWidth' : 2,
@@ -167,8 +167,8 @@ def defaultPreferences():
             }
 
  # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
- #   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -  
- #     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -    
+ #   - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
+ #     - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 
 
 
@@ -176,15 +176,17 @@ def defaultPreferences():
 # - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 # Functions that handle preferences
 """
-The following plugin functions by default expect the name and path of the preferences file to be the 
-main lasagna preferences file. However, this can be over-ridden so that indiviual plugins can have 
-their own preferences files and still use these functions. 
+The following plugin functions by default expect the name and path of the preferences file to be the
+main lasagna preferences file. However, this can be over-ridden so that indiviual plugins can have
+their own preferences files and still use these functions.
 """
 
-def loadAllPreferences(prefFName=getLasagnaPrefFile(),defaultPref=defaultPreferences()):
+def loadAllPreferences(prefFName=getLasagnaPrefFile(),defaultPref=defaultPreferences(),
+                       defaultMissingPrefs=False):
     """
     Load the preferences YAML file. If the file is missing, we create it using the default
     preferences defined above. Preferences are returned as a dictionary.
+    if defaultMissingPrefs populate prefs absent in loaded file with default
     """
     #print "loading from pref file %s" % prefFName
     #Generate a default preferences file if no preferences file exists
@@ -195,22 +197,26 @@ def loadAllPreferences(prefFName=getLasagnaPrefFile(),defaultPref=defaultPrefere
         print "Created default preferences file in " + prefFName
 
     #Load preferences YAML file as a dictionary
-    with file(prefFName, 'r') as stream: 
-        return yaml.load(stream)
+    with file(prefFName, 'r') as stream:
+        prefs= yaml.load(stream)
+    if defaultMissingPrefs:
+        defaultPref.update(prefs)
+        prefs=defaultPref
+    return prefs
 
 
 
 def readPreference(preferenceName,prefFName=getLasagnaPrefFile(), preferences=getLasagnaPrefFile()):
     """
     Read preferences with key "preferenceName" from YAML file prefFName on disk.
-    If the key is abstent, call defaultPreferences and search for the key. If it
+    If the key is absent, call defaultPreferences and search for the key. If it
     is present, add to preferences file and return the value. If absent, raise a
-    warning and return None. The caller function needs to decide what to do with 
-    the None. 
+    warning and return None. The caller function needs to decide what to do with
+    the None.
     """
-    
+
     #TODO: need some sort of check as to whether the preference value is valid
-    
+
     #Check on disk
     preferences = loadAllPreferences(prefFName)
     if preferences.has_key(preferenceName):

--- a/tutorialPlugins/embelishStatusBar_plugin.py
+++ b/tutorialPlugins/embelishStatusBar_plugin.py
@@ -24,7 +24,7 @@ class plugin(lasagna_plugin):
     """
 
     def hook_updateStatusBar_End(self):
-        self.lasagna.statusBarText = "CuReNt CoOrDiNaTeS: " + self.lasagna.statusBarText 
+        self.lasagna.statusBarText = "CuReNt CoOrDiNaTeS: " + self.lasagna.statusBarText + 'Slice %s'%self.lasagna.axes2D[0].currentSlice
 
     def closePlugin(self):
         self.detachHooks()


### PR DESCRIPTION
Found a very weird bug in the tree reader plugin. Briefly, loading one tree affected the way a second tree was loaded. This was the issue: #164 This was happening because a variable used in a recursive function call was hanging around somewhere. I still don't know where or why (maybe you understand?). The issue was corrected here: 942d53d and has been merged into my master branch. 