### PR TITLE
Reorder stack plugin

### DIFF
--- a/registrationPlugins/reorder_stack.ui
+++ b/registrationPlugins/reorder_stack.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>reorderStack</class>
+ <widget class="QDialog" name="reorderStack">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>268</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>reorder_stack</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout_3">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QListWidget" name="listWidget">
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <spacer name="verticalSpacer_2">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QToolButton" name="up_toolButton">
+         <property name="text">
+          <string>...</string>
+         </property>
+         <property name="arrowType">
+          <enum>Qt::UpArrow</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QToolButton" name="down_toolButton">
+         <property name="text">
+          <string>...</string>
+         </property>
+         <property name="arrowType">
+          <enum>Qt::DownArrow</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="update_checkBox">
+         <property name="text">
+          <string>update</string>
+         </property>
+         <property name="checked">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QPushButton" name="doit_pushButton">
+         <property name="text">
+          <string>do it!</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QPushButton" name="closeButton">
+     <property name="text">
+      <string>&amp;Close</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>

--- a/registrationPlugins/reorder_stack_UI.py
+++ b/registrationPlugins/reorder_stack_UI.py
@@ -1,0 +1,81 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'reorder_stack.ui'
+#
+# Created by: PyQt4 UI code generator 4.11.4
+#
+# WARNING! All changes made in this file will be lost!
+
+from PyQt4 import QtCore, QtGui
+
+try:
+    _fromUtf8 = QtCore.QString.fromUtf8
+except AttributeError:
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
+
+class Ui_reorderStack(object):
+    def setupUi(self, reorderStack):
+        reorderStack.setObjectName(_fromUtf8("reorderStack"))
+        reorderStack.resize(268, 300)
+        self.verticalLayout_3 = QtGui.QVBoxLayout(reorderStack)
+        self.verticalLayout_3.setObjectName(_fromUtf8("verticalLayout_3"))
+        self.horizontalLayout = QtGui.QHBoxLayout()
+        self.horizontalLayout.setObjectName(_fromUtf8("horizontalLayout"))
+        self.verticalLayout_2 = QtGui.QVBoxLayout()
+        self.verticalLayout_2.setObjectName(_fromUtf8("verticalLayout_2"))
+        self.label = QtGui.QLabel(reorderStack)
+        self.label.setObjectName(_fromUtf8("label"))
+        self.verticalLayout_2.addWidget(self.label)
+        self.listWidget = QtGui.QListWidget(reorderStack)
+        self.listWidget.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
+        self.listWidget.setObjectName(_fromUtf8("listWidget"))
+        self.verticalLayout_2.addWidget(self.listWidget)
+        self.horizontalLayout.addLayout(self.verticalLayout_2)
+        self.verticalLayout = QtGui.QVBoxLayout()
+        self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
+        spacerItem = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+        self.verticalLayout.addItem(spacerItem)
+        self.up_toolButton = QtGui.QToolButton(reorderStack)
+        self.up_toolButton.setArrowType(QtCore.Qt.UpArrow)
+        self.up_toolButton.setObjectName(_fromUtf8("up_toolButton"))
+        self.verticalLayout.addWidget(self.up_toolButton)
+        self.down_toolButton = QtGui.QToolButton(reorderStack)
+        self.down_toolButton.setArrowType(QtCore.Qt.DownArrow)
+        self.down_toolButton.setObjectName(_fromUtf8("down_toolButton"))
+        self.verticalLayout.addWidget(self.down_toolButton)
+        spacerItem1 = QtGui.QSpacerItem(20, 40, QtGui.QSizePolicy.Minimum, QtGui.QSizePolicy.Expanding)
+        self.verticalLayout.addItem(spacerItem1)
+        self.update_checkBox = QtGui.QCheckBox(reorderStack)
+        self.update_checkBox.setChecked(True)
+        self.update_checkBox.setObjectName(_fromUtf8("update_checkBox"))
+        self.verticalLayout.addWidget(self.update_checkBox)
+        self.doit_pushButton = QtGui.QPushButton(reorderStack)
+        self.doit_pushButton.setObjectName(_fromUtf8("doit_pushButton"))
+        self.verticalLayout.addWidget(self.doit_pushButton)
+        self.horizontalLayout.addLayout(self.verticalLayout)
+        self.verticalLayout_3.addLayout(self.horizontalLayout)
+        self.closeButton = QtGui.QPushButton(reorderStack)
+        self.closeButton.setObjectName(_fromUtf8("closeButton"))
+        self.verticalLayout_3.addWidget(self.closeButton)
+
+        self.retranslateUi(reorderStack)
+        QtCore.QMetaObject.connectSlotsByName(reorderStack)
+
+    def retranslateUi(self, reorderStack):
+        reorderStack.setWindowTitle(_translate("reorderStack", "reorder_stack", None))
+        self.label.setText(_translate("reorderStack", "TextLabel", None))
+        self.up_toolButton.setText(_translate("reorderStack", "...", None))
+        self.down_toolButton.setText(_translate("reorderStack", "...", None))
+        self.update_checkBox.setText(_translate("reorderStack", "update", None))
+        self.doit_pushButton.setText(_translate("reorderStack", "do it!", None))
+        self.closeButton.setText(_translate("reorderStack", "&Close", None))
+

--- a/registrationPlugins/reorder_stack_plugin.py
+++ b/registrationPlugins/reorder_stack_plugin.py
@@ -62,10 +62,6 @@ class plugin(lasagna_plugin, QtGui.QWidget, reorder_stack_UI.Ui_reorderStack): #
         item = self.listWidget.takeItem(indice)
         self.listWidget.insertItem(indice-1,item)
         self.listWidget.setCurrentRow(indice-1)
-        # if self.update_checkBox.isChecked():
-        #     for axis in self.lasagna.axes2D:
-        #         axis.updatePlotItems_2D(self.lasagna.ingredientList,
-        #                                 sliceToPlot=int(item.text().split(' ')[1]))
 
     def move_down(self):
         indice = [i.row() for i in self.listWidget.selectedIndexes()]
@@ -81,20 +77,31 @@ class plugin(lasagna_plugin, QtGui.QWidget, reorder_stack_UI.Ui_reorderStack): #
         item = self.listWidget.takeItem(indice)
         self.listWidget.insertItem(indice+1,item)
         self.listWidget.setCurrentRow(indice+1)
-        # if self.update_checkBox.isChecked():
-        #     for axis in self.lasagna.axes2D:
-        #         axis.updatePlotItems_2D(self.lasagna.ingredientList,
-        #                                 sliceToPlot=int(item.text().split(' ')[1]))
 
-    def update_plot(self):
-        item = self.listWidget.selectedItems()
-        if not len(item):
+    def update_plot(self, current=None, previous=None):
+        """Update the drawn slice
+
+        Current and Previous are arguments sent by currentItemChanged. If they are none
+        just take the first (and only) selected item
+        """
+        # update only if the box is checked
+        if not self.update_checkBox.isChecked():
             return
-        item = item[0]
-        if self.update_checkBox.isChecked():
-            for axis in self.lasagna.axes2D:
-                axis.updatePlotItems_2D(self.lasagna.ingredientList,
-                                        sliceToPlot=int(item.text().split(' ')[1]))
+
+        if current is None:
+            # we have no items provided, just take what is selected
+            item = self.listWidget.selectedItems()
+            if not len(item):
+                # nothing is selected, return
+                return
+            item = item[0]
+        else:
+            # we have an item, ignore the previous, use the current
+            item = current
+
+        for axis in self.lasagna.axes2D:
+            axis.updatePlotItems_2D(self.lasagna.ingredientList,
+                                    sliceToPlot=int(item.text().split(' ')[1]))
 
 
     def doit(self):

--- a/registrationPlugins/reorder_stack_plugin.py
+++ b/registrationPlugins/reorder_stack_plugin.py
@@ -1,0 +1,151 @@
+"""
+A simple plugin just to change the order of the slices
+"""
+
+from lasagna_plugin import lasagna_plugin
+import reorder_stack_UI
+import selectstack_UI
+from PyQt4 import QtGui, QtCore
+import sys
+import numpy as np
+
+
+import lasagna_helperFunctions            # A potentially temporary module that houses general-purpose helper functions
+
+class plugin(lasagna_plugin, QtGui.QWidget, reorder_stack_UI.Ui_reorderStack): #must inherit lasagna_plugin first
+
+    def __init__(self,lasagna,parent=None):
+        super(plugin,self).__init__(lasagna) #This calls the lasagna_plugin constructor which in turn calls subsequent constructors
+
+        #re-define some default properties that were originally defined in lasagna_plugin
+        self.pluginShortName='Reorder stack' #Appears on the menu
+        self.pluginLongName='manually reorder a stack' #Can be used for other purposes (e.g. tool-tip)
+        self.pluginAuthor='Antonin Blot'
+
+        #Create widgets defined in the designer file
+        self.setupUi(self)
+        self.show()
+        self.initialise()
+
+        # Connections:
+        self.closeButton.clicked.connect(self.close)
+        self.down_toolButton.clicked.connect(self.move_down)
+        self.up_toolButton.clicked.connect(self.move_up)
+        self.listWidget.currentItemChanged.connect(self.update_plot)
+        self.doit_pushButton.clicked.connect(self.doit)
+
+    def initialise(self):
+        self.listWidget.clear()
+        self.stack_name = self.lasagna.selectedStackName()
+        self.label.setText(self.stack_name)
+
+        stk = self.lasagna.returnIngredientByName(self.stack_name)
+        nslices = stk._data.shape[0]
+        for i in range(nslices):
+            self.listWidget.addItem('slice %i'%i)
+
+
+    def move_up(self):
+        """moves selected slices up
+        """
+
+        indice = [i.row() for i in self.listWidget.selectedIndexes()]
+        if not len(indice):
+            print 'Select a slice to move it'
+            return
+        elif len(indice) != 1:
+            raise IOError('Should not accept multiple selection. Change UI')
+        indice = indice[0]
+        if indice==0:
+            print 'already first'
+            return
+        item = self.listWidget.takeItem(indice)
+        self.listWidget.insertItem(indice-1,item)
+        self.listWidget.setCurrentRow(indice-1)
+        # if self.update_checkBox.isChecked():
+        #     for axis in self.lasagna.axes2D:
+        #         axis.updatePlotItems_2D(self.lasagna.ingredientList,
+        #                                 sliceToPlot=int(item.text().split(' ')[1]))
+
+    def move_down(self):
+        indice = [i.row() for i in self.listWidget.selectedIndexes()]
+        if not len(indice):
+            print 'Select a slice to move it'
+            return
+        elif len(indice) != 1:
+            raise IOError('Should not accept multiple selection. Change UI')
+        indice = indice[0]
+        if indice== self.listWidget.count()-1:
+            print 'already last'
+            return
+        item = self.listWidget.takeItem(indice)
+        self.listWidget.insertItem(indice+1,item)
+        self.listWidget.setCurrentRow(indice+1)
+        # if self.update_checkBox.isChecked():
+        #     for axis in self.lasagna.axes2D:
+        #         axis.updatePlotItems_2D(self.lasagna.ingredientList,
+        #                                 sliceToPlot=int(item.text().split(' ')[1]))
+
+    def update_plot(self):
+        item = self.listWidget.selectedItems()
+        if not len(item):
+            return
+        item = item[0]
+        if self.update_checkBox.isChecked():
+            for axis in self.lasagna.axes2D:
+                axis.updatePlotItems_2D(self.lasagna.ingredientList,
+                                        sliceToPlot=int(item.text().split(' ')[1]))
+
+
+    def doit(self):
+        stk_list = [st.objectName for st in self.lasagna.returnIngredientByType('imagestack')]
+        dlg = SelectStack(self, stk_list)
+        results = dlg.exec_()
+        if not results:
+            print 'Cancel'
+            return
+        values = dlg.getValues()
+
+        if not len(values):
+            print 'Nothing selected, do nothing'
+            return
+
+        order =  [self.listWidget.item(i) for i in range(self.listWidget.count())]
+        order = [int(l.text().split(' ')[1]) for l in order]
+        for stck_name in values:
+            stk = self.lasagna.returnIngredientByName(str(stck_name))
+            stk._data = stk._data[order,:,:]
+        self.initialise()
+
+
+    #The following methods are involved in shutting down the plugin window
+    def closePlugin(self):
+        """
+        This method is called by lasagna when the user unchecks the plugin in the menu.
+        """
+        self.detachHooks()
+        self.close()
+
+
+
+    #We define this here because we can't assume all plugins will have QWidget::closeEvent
+    def closeEvent(self, event):
+        """
+        This event is executed when the user presses the close window (cross) button in the title bar
+        """
+        self.lasagna.stopPlugin(self.__module__) #This will call self.closePlugin
+        self.lasagna.pluginActions[self.__module__].setChecked(False) #Uncheck the menu item associated with this plugin's name
+        self.deleteLater()
+        event.accept()
+
+
+class SelectStack(QtGui.QDialog, selectstack_UI.Ui_selectStack): #must inherit lasagna_plugin first)
+    def __init__(self, parent=None, stack_list=[]):
+        super(SelectStack, self).__init__(parent) #This calls the lasagna_plugin constructor which in turn calls subsequent constructors
+        self.setupUi(self)
+
+        for st in stack_list:
+            self.listWidget.addItem(st)
+
+    def getValues(self):
+        return [i.text() for i in self.listWidget.selectedItems()]

--- a/registrationPlugins/selectstack.ui
+++ b/registrationPlugins/selectstack.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>selectStack</class>
+ <widget class="QDialog" name="selectStack">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>248</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Select stack</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Select stack to change</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QListWidget" name="listWidget">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::ExtendedSelection</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>selectStack</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>selectStack</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/registrationPlugins/selectstack_UI.py
+++ b/registrationPlugins/selectstack_UI.py
@@ -1,0 +1,58 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'selectstack.ui'
+#
+# Created by: PyQt4 UI code generator 4.11.4
+#
+# WARNING! All changes made in this file will be lost!
+
+from PyQt4 import QtCore, QtGui
+
+try:
+    _fromUtf8 = QtCore.QString.fromUtf8
+except AttributeError:
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
+
+class Ui_selectStack(object):
+    def setupUi(self, selectStack):
+        selectStack.setObjectName(_fromUtf8("selectStack"))
+        selectStack.resize(248, 300)
+        self.verticalLayout = QtGui.QVBoxLayout(selectStack)
+        self.verticalLayout.setObjectName(_fromUtf8("verticalLayout"))
+        self.horizontalLayout = QtGui.QHBoxLayout()
+        self.horizontalLayout.setObjectName(_fromUtf8("horizontalLayout"))
+        self.label = QtGui.QLabel(selectStack)
+        self.label.setObjectName(_fromUtf8("label"))
+        self.horizontalLayout.addWidget(self.label)
+        spacerItem = QtGui.QSpacerItem(40, 20, QtGui.QSizePolicy.Expanding, QtGui.QSizePolicy.Minimum)
+        self.horizontalLayout.addItem(spacerItem)
+        self.verticalLayout.addLayout(self.horizontalLayout)
+        self.listWidget = QtGui.QListWidget(selectStack)
+        self.listWidget.setEditTriggers(QtGui.QAbstractItemView.NoEditTriggers)
+        self.listWidget.setSelectionMode(QtGui.QAbstractItemView.ExtendedSelection)
+        self.listWidget.setObjectName(_fromUtf8("listWidget"))
+        self.verticalLayout.addWidget(self.listWidget)
+        self.buttonBox = QtGui.QDialogButtonBox(selectStack)
+        self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
+        self.buttonBox.setStandardButtons(QtGui.QDialogButtonBox.Cancel|QtGui.QDialogButtonBox.Ok)
+        self.buttonBox.setObjectName(_fromUtf8("buttonBox"))
+        self.verticalLayout.addWidget(self.buttonBox)
+
+        self.retranslateUi(selectStack)
+        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("accepted()")), selectStack.accept)
+        QtCore.QObject.connect(self.buttonBox, QtCore.SIGNAL(_fromUtf8("rejected()")), selectStack.reject)
+        QtCore.QMetaObject.connectSlotsByName(selectStack)
+
+    def retranslateUi(self, selectStack):
+        selectStack.setWindowTitle(_translate("selectStack", "Select stack", None))
+        self.label.setText(_translate("selectStack", "Select stack to change", None))
+

--- a/registrationPlugins/updatePluginUIs.sh
+++ b/registrationPlugins/updatePluginUIs.sh
@@ -1,3 +1,5 @@
 pyuic4 elastix_plugin.ui > elastix_plugin_UI.py
 pyrcc4 ./elastix_plugin.qrc >  ./elastix_plugin_rc.py
 pyuic4 transformix_plugin.ui > transformix_plugin_UI.py
+pyuic4 reorder_stack.ui > reorder_stack_UI.py
+pyuic4 selectstack.ui > selectstack_UI.py

--- a/registrationPlugins/updatePluginUIs.sh
+++ b/registrationPlugins/updatePluginUIs.sh
@@ -1,3 +1,4 @@
+#!/usr/bin/env bash
 pyuic4 elastix_plugin.ui > elastix_plugin_UI.py
 pyrcc4 ./elastix_plugin.qrc >  ./elastix_plugin_rc.py
 pyuic4 transformix_plugin.ui > transformix_plugin_UI.py


### PR DESCRIPTION
A simple plugin to manually reorder stacks.

It happens sometimes that I mount slices weirdly and invert two slices. Reverting the order in the stack is not convenient to do in Fiji. This small plugin gives a GUI to do that quickly.