### PR TITLE
Save tiff stack

### DIFF
--- a/imageStackLoader.py
+++ b/imageStackLoader.py
@@ -119,7 +119,7 @@ def saveTiffStack(fname, data, useLibTiff = False):
     if useLibTiff:
         raise NotImplementedError
     from tifffile import imsave
-    imsave(fname, data.swapaxes(1,2))
+    imsave(str(fname), data.swapaxes(1,2))
 
 #-------------------------------------------------------------------------------------------
 #   *MHD handling methods*

--- a/imageStackLoader.py
+++ b/imageStackLoader.py
@@ -34,6 +34,15 @@ def loadStack(fname):
   else:
     print "\n\n*" + fname + " NOT LOADED. DATA TYPE NOT KNOWN\n\n"
 
+def saveStack(fname, data, format='tif'):
+  """Save the image data
+  Works only for tif for now
+  """
+  format = format.lower().strip().strip('.')
+  if format in ['tif', 'tiff']:
+    saveTiffStack(fname, data)
+  else:
+    raise NotImplementedError
 
 def imageFilter():
   """
@@ -104,7 +113,13 @@ def loadTiffStack(fname,useLibTiff=False):
   print "read image of size: cols: %d, rows: %d, layers: %d" % (im.shape[1],im.shape[2],im.shape[0])
   return im
 
-
+def saveTiffStack(fname, data, useLibTiff = False):
+    """Save data in file fname
+    """
+    if useLibTiff:
+        raise NotImplementedError
+    from tifffile import imsave
+    imsave(fname, data.swapaxes(1,2))
 
 #-------------------------------------------------------------------------------------------
 #   *MHD handling methods*

--- a/ingredients/imagestack.py
+++ b/ingredients/imagestack.py
@@ -8,6 +8,7 @@ import os
 from PyQt4 import QtGui, QtCore
 import pyqtgraph as pg
 from  lasagna_ingredient import lasagna_ingredient 
+from imageStackLoader import saveStack
 
 class imagestack(lasagna_ingredient):
     def __init__(self, parent=None, data=None, fnameAbsPath='', enable=True, objectName='', minMax=None, lut='gray'):
@@ -261,7 +262,13 @@ class imagestack(lasagna_ingredient):
                 self.parent.ingredientList[0].lut='gray'
                 self.parent.initialiseAxes()
 
-
+    def save(self, path=None):
+        if path is None:
+            path = QtGui.QFileDialog.getSaveFileName(self.parent, 'File to save %s' % self.objectName)
+        if not path:
+            return
+        saveStack(path, self.raw_data())
+        print '%s saved as %s' % (self.objectName, path)
 
 
     #---------------------------------------------------------------

--- a/lasagna.py
+++ b/lasagna.py
@@ -1120,6 +1120,9 @@ class lasagna(QtGui.QMainWindow, lasagna_mainWindow.Ui_lasagna_mainWindow):
         action = QtGui.QAction("Delete",self)
         action.triggered.connect(self.deleteLayerStack_Slot)
         menu.addAction(action)
+        action = QtGui.QAction("Save",self)
+        action.triggered.connect(self.saveLayerStack_Slot)
+        menu.addAction(action)
         menu.exec_(self.imageStackLayers_TreeView.viewport().mapToGlobal(position))
 
 
@@ -1143,6 +1146,14 @@ class lasagna(QtGui.QMainWindow, lasagna_mainWindow.Ui_lasagna_mainWindow):
         print "removed " + objName
         self.runHook(self.hooks['deleteLayerStack_Slot_End'])
 
+    def saveLayerStack_Slot(self):
+        """call stack save method"""
+        objName =  self.selectedStackName()
+        ingr = self.returnIngredientByName(objName)
+        if hasattr(ingr, 'save'):
+            ingr.save()
+        else:
+            print 'no save method for %s'%objName
 
     def stacksInTreeList(self):
         """


### PR DESCRIPTION
Add an option to save a tiff stack from lasagna (useful after reordering for instance)

It sits in the contextual menu next to the delete action and works only for tiff files and only when using the tifffile package. It should raise a NonImplemented error otherwise but I haven't tested that