### PR TITLE
More than 6colors

### DIFF
--- a/ingredients/imagestack.py
+++ b/ingredients/imagestack.py
@@ -120,7 +120,7 @@ class imagestack(lasagna_ingredient):
             return self.histBrushCustomColor
 
         cMap = self.setColorMap(self.lut)
-        return cMap[round(len(cMap)/2),:]
+        return cMap[int(round(len(cMap)/2)),:]
 
 
     def histPenColor(self):

--- a/ingredients/lines.py
+++ b/ingredients/lines.py
@@ -54,9 +54,9 @@ class lines(lasagna_ingredient):
         self.addToList()
 
         #Set the colour of the object based on how many items are already present
-        thisNumber = self.parent.points_Model.rowCount()-1
         number_of_colors = 6
-        cm_subsection = linspace(0, 1, number_of_colors) 
+        thisNumber = (self.parent.points_Model.rowCount() - 1) % number_of_colors
+        cm_subsection = linspace(0, 1, number_of_colors)
         colors = [ cm.jet(x) for x in cm_subsection ]
         color = colors[thisNumber]
         self.color = [color[0]*255, color[1]*255, color[2]*255]

--- a/ingredients/sparsepoints.py
+++ b/ingredients/sparsepoints.py
@@ -43,9 +43,9 @@ class sparsepoints(lasagna_ingredient):
         self.addToList()
 
         #Set the colour of the object based on how many items are already present
-        thisNumber = self.parent.points_Model.rowCount()-1
         number_of_colors = 6
-        cm_subsection = linspace(0, 1, number_of_colors) 
+        thisNumber = (self.parent.points_Model.rowCount()-1)%number_of_colors
+        cm_subsection = linspace(0, 1, number_of_colors)
         colors = [ cm.jet(x) for x in cm_subsection ]
         color = colors[thisNumber]
         self.color = [color[0]*255, color[1]*255, color[2]*255]


### PR DESCRIPTION
When more than 6 sparsepoint or line ingredients are added, the automatic color increment raises an error. Add a `% number_of_color` to cycle through available colours.
