### PR TITLE
Minor bugfix

### DIFF
--- a/tutorialPlugins/overlayRandomPoints_plugin.py
+++ b/tutorialPlugins/overlayRandomPoints_plugin.py
@@ -52,10 +52,10 @@ class plugin(lasagna_plugin):
 
         imShape = firstLayer.data().shape
 
-        n = 10E3 #number of random points to make
+        n = 10000 #number of random points to make
         numAxes = 3
 
-        r = np.random.rand(n*numAxes).reshape((n,numAxes)) #the random array
+        r = np.random.rand(n*numAxes).reshape((n, numAxes)) #the random array
 
         #multiply values in each dimension of the array by the array size of the first layer image
         for ii in range(numAxes):


### PR DESCRIPTION
10E3 is a float and that was causing a crash with reshape in more
recent versions of numpy. Replace by 10000 to fix.